### PR TITLE
TraceMe: replace id generator to have a smaller cookie value

### DIFF
--- a/cas-toolbox-core/src/main/java/org/esupportail/cas/services/TraceMeMetaDataPopulator.java
+++ b/cas-toolbox-core/src/main/java/org/esupportail/cas/services/TraceMeMetaDataPopulator.java
@@ -41,16 +41,13 @@ public final class TraceMeMetaDataPopulator implements AuthenticationMetaDataPop
 	@NotNull
 	private CookieRetrievingCookieGenerator traceMeCookieGenerator;
 	
-	@NotNull
-	private UniqueTicketIdGenerator traceMeUniqueIdGenerator;
-	
 	private boolean enabled = false;
 	
 	@Override
 	public void populateAttributes(final AuthenticationBuilder builder, final Credential credential) {
 		if(enabled) {
 			if (credential instanceof UsernamePasswordCredential) {
-				String id = traceMeUniqueIdGenerator.getNewTicketId("TRACE");
+				String id = java.util.UUID.randomUUID().toString();
 				String principalId = builder.getPrincipal().getId();
 				
 				ExternalContext externalContext = ExternalContextHolder.getExternalContext();
@@ -76,7 +73,7 @@ public final class TraceMeMetaDataPopulator implements AuthenticationMetaDataPop
 		this.traceMeCookieGenerator= traceMeCookieGenerator;
 	}
 
+	@Deprecated
 	public void setTraceMeUniqueIdGenerator(final UniqueTicketIdGenerator uniqueTicketIdGenerator) {
-		this.traceMeUniqueIdGenerator = uniqueTicketIdGenerator;
 	}
 }

--- a/cas-toolbox-core/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-toolbox-core/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -66,7 +66,6 @@
               <bean class="org.esupportail.cas.services.TraceMeMetaDataPopulator">
                   <property name="enabled" value="${trace.enabled}"/>
                   <property name="traceMeCookieGenerator" ref="traceMeCookieGenerator"/>
-                  <property name="traceMeUniqueIdGenerator" ref="traceMeUniqueIdGenerator"/>
               </bean>
               <!-- IF USE ESUP TraceMe : stop -->
            </util:list>

--- a/cas-toolbox-core/src/main/webapp/WEB-INF/spring-configuration/trace-me.xml
+++ b/cas-toolbox-core/src/main/webapp/WEB-INF/spring-configuration/trace-me.xml
@@ -34,14 +34,5 @@
 				p:cookieName="${trace.cookieName}"
 				p:cookiePath="${trace.cookiePath}"
 				p:cookieDomain="${trace.cookieDomain}"/>
-	
-	<bean id="traceMeUniqueIdGenerator" class="org.jasig.cas.util.DefaultUniqueTicketIdGenerator">
-		<constructor-arg
-			index="0"
-			type="int"
-			value="${trace.ramdomMaxLength}" />
-		<constructor-arg
-			index="1" value="${host.name}" />
-	</bean>
 	<!--  IF USE ESUP traceMe : stop -->
 </beans>

--- a/cas-toolbox-custom/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-toolbox-custom/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -66,7 +66,6 @@
               <bean class="org.esupportail.cas.services.TraceMeMetaDataPopulator">
                   <property name="enabled" value="${trace.enabled}"/>
                   <property name="traceMeCookieGenerator" ref="traceMeCookieGenerator"/>
-                  <property name="traceMeUniqueIdGenerator" ref="traceMeUniqueIdGenerator"/>
               </bean>
               <!-- IF USE ESUP TraceMe : stop -->
            </util:list>


### PR DESCRIPTION
before:
  TRACE-9999999-YdqqRVgeM7HnnMBu0d65kEiFqRbUqPiDDugU3spBbKwiZRcGKZ-cas
after:
  bf2616a3-c00a-497a-97e4-4b2ec2f49db4 (standard UUID, 128 bits)
  TRACE-9999999-0123456

refs:
https://listes.esup-portail.org/sympa/arc/esup-utilisateurs/2015-12/msg00017.html
https://listes.esup-portail.org/sympa/arc/esup-utilisateurs/2016-01/msg00001.html
